### PR TITLE
Handle colon-based Spotify URLs correctly

### DIFF
--- a/mbot/utils/mainhelper.py
+++ b/mbot/utils/mainhelper.py
@@ -40,7 +40,10 @@ def parse_deezer_url(url):
 @sync_to_async
 def parse_spotify_url(url):
     if url.startswith("spotify"):
-        return url.split(":")[1]
+        parts = url.split(":")
+        if len(parts) >= 3:
+            return parts[1], parts[2]
+        raise ValueError("Invalid Spotify URL format")
     url = get(url).url
     parsed_url = url.replace("https://open.spotify.com/", "").split("/")
     return parsed_url[0], parsed_url[1].split("?")[0]

--- a/tests/test_parse_spotify_url.py
+++ b/tests/test_parse_spotify_url.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from pathlib import Path
+
+import asyncio
+
+os.environ.setdefault("API_ID", "1")
+os.environ.setdefault("API_HASH", "hash")
+os.environ.setdefault("BOT_TOKEN", "token")
+os.environ.setdefault("OWNER_ID", "1")
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from mbot.utils.mainhelper import parse_spotify_url
+
+
+def test_parse_spotify_url_with_spotify_scheme():
+    item_type, item_id = asyncio.run(parse_spotify_url("spotify:track:12345"))
+    assert item_type == "track"
+    assert item_id == "12345"
+
+
+def test_parse_spotify_url_with_http_url(monkeypatch):
+    class MockResponse:
+        def __init__(self, url):
+            self.url = url
+
+    def mock_get(url):
+        return MockResponse(url)
+
+    monkeypatch.setattr("mbot.utils.mainhelper.get", mock_get)
+    item_type, item_id = asyncio.run(parse_spotify_url("https://open.spotify.com/track/abcde"))
+    assert item_type == "track"
+    assert item_id == "abcde"


### PR DESCRIPTION
## Summary
- fix `parse_spotify_url` to return both item type and id for `spotify:` style links
- add tests covering Spotify URL parsing for colon and http formats

## Testing
- `python -m py_compile mbot/utils/mainhelper.py tests/test_parse_spotify_url.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af689577408323b014a7b525707488