### PR TITLE
Remove downloaded songs after upload

### DIFF
--- a/mbot/plugins/deezer.py
+++ b/mbot/plugins/deezer.py
@@ -21,8 +21,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from os import mkdir
+from os import mkdir, remove
 from random import randint
+from shutil import rmtree
 
 from deezer import Client
 from pyrogram import filters
@@ -75,6 +76,9 @@ async def link_handler(_, message):
                 if LOG_GROUP:
                     await PForCopy.copy(LOG_GROUP)
                     await AForCopy.copy(LOG_GROUP)
+                remove(path)
+                remove(thumbnail)
+            rmtree(randomdir, ignore_errors=True)
             await m.delete()
         elif item_type == "artist":
             await m.edit_text(

--- a/mbot/plugins/spotify.py
+++ b/mbot/plugins/spotify.py
@@ -21,8 +21,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from os import mkdir
+from os import mkdir, remove
 from random import randint
+from shutil import rmtree
 
 import spotipy
 from pyrogram import filters
@@ -80,6 +81,9 @@ async def spotify_dl(_, message):
                 )
                 if LOG_GROUP:
                     await copy(PForCopy, AForCopy)
+                remove(fileLink)
+                remove(thumbnail)
+            rmtree(randomdir, ignore_errors=True)
             return await m.delete()
         elif item_type == "track":
             song = await fetch_spotify_track(client, item_id)
@@ -98,6 +102,9 @@ async def spotify_dl(_, message):
             )
             if LOG_GROUP:
                 await copy(PForCopy, AForCopy)
+            remove(path)
+            remove(thumbnail)
+            rmtree(randomdir, ignore_errors=True)
             return await m.delete()
         elif item_type == "playlist":
             tracks = client.playlist_items(
@@ -127,6 +134,9 @@ async def spotify_dl(_, message):
                 track_no += 1
                 if LOG_GROUP:
                     await copy(PForCopy, AForCopy)
+                remove(path)
+                remove(thumbnail)
+            rmtree(randomdir, ignore_errors=True)
             return await m.delete()
         elif item_type == "album":
             tracks = client.album_tracks(album_id=item_id)
@@ -149,6 +159,9 @@ async def spotify_dl(_, message):
                 )
                 if LOG_GROUP:
                     await copy(PForCopy, AForCopy)
+                remove(path)
+                remove(thumbnail)
+            rmtree(randomdir, ignore_errors=True)
             return await m.delete()
     except Exception as e:
         LOGGER.error(e)

--- a/mbot/plugins/youtube.py
+++ b/mbot/plugins/youtube.py
@@ -21,8 +21,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from os import mkdir
+from os import mkdir, remove
 from random import randint
+from shutil import rmtree
 
 from pyrogram import filters
 
@@ -71,6 +72,9 @@ async def _(_, message):
             if LOG_GROUP:
                 await PForCopy.copy(LOG_GROUP)
                 await AForCopy.copy(LOG_GROUP)
+            remove(fileLink)
+            remove(thumnail)
+        rmtree(randomdir, ignore_errors=True)
         await m.delete()
     except Exception as e:
         LOGGER.error(e)


### PR DESCRIPTION
## Summary
- delete downloaded YouTube songs and thumbnails once sent
- clean up Spotify downloads and temp artwork after upload
- remove Deezer audio files and thumbnails and clear temp directories

## Testing
- `python -m py_compile mbot/plugins/deezer.py mbot/plugins/spotify.py mbot/plugins/youtube.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af693a69e88323a441688edc0e9f10