### PR TITLE
Add download progress bar

### DIFF
--- a/mbot/plugins/youtube.py
+++ b/mbot/plugins/youtube.py
@@ -21,6 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from asyncio import AbstractEventLoop
 from os import mkdir, remove
 from random import randint
 from shutil import rmtree
@@ -31,13 +32,42 @@ from mbot import AUTH_CHATS, LOG_GROUP, LOGGER, Mbot
 from mbot.utils.ytdl import audio_opt, getIds, thumb_down, ytdl_down
 
 
+def progress_hook_factory(client, message, index, total, title):
+    bar_length = 20
+    loop: AbstractEventLoop = client.loop
+
+    def hook(d):
+        status = d.get("status")
+        if status == "downloading":
+            percent = d.get("_percent_str", "0%").strip()
+            try:
+                p = float(percent.strip("%"))
+            except ValueError:
+                p = 0
+            filled = int(bar_length * p // 100)
+            bar = "█" * filled + "░" * (bar_length - filled)
+            text = (
+                f"Downloading {index}/{total}\n"
+                f"{title}\n"
+                f"`[{bar}] {percent}`"
+            )
+            loop.call_soon_threadsafe(loop.create_task, message.edit_text(text))
+        elif status == "finished":
+            loop.call_soon_threadsafe(
+                loop.create_task,
+                message.edit_text("Download complete, processing..."),
+            )
+
+    return hook
+
+
 @Mbot.on_message(
     filters.regex(r"(https?://)?.*you[^\s]+") & filters.private
     | filters.command(["yt", "ytd", "ytmusic"])
     & filters.regex(r"https?://.*you[^\s]+")
     & filters.chat(AUTH_CHATS)
 )
-async def _(_, message):
+async def _(client, message):
     m = await message.reply_text("Gathering information... Please Wait.")
     link = message.matches[0].group(0)
     if link in [
@@ -54,12 +84,18 @@ async def _(_, message):
         videoInPlaylist = len(ids)
         randomdir = "/tmp/" + str(randint(1, 100000000))
         mkdir(randomdir)
-        for id in ids:
+        for idx, id in enumerate(ids, start=1):
+            await m.edit_text(f"Starting download {idx}/{videoInPlaylist}...")
             PForCopy = await message.reply_photo(
                 f"https://i.ytimg.com/vi/{id[0]}/hqdefault.jpg",
                 caption=f"🎧 Title : `{id[3]}`\n🎤 Artist : `{id[2]}`\n💽 Track No : `{id[1]}`\n💽 Total Track : `{videoInPlaylist}`",
             )
-            fileLink = await ytdl_down(audio_opt(randomdir, id[2]), id[0])
+            opts = audio_opt(randomdir, id[2])
+            opts["progress_hooks"] = [
+                progress_hook_factory(client, m, idx, videoInPlaylist, id[3])
+            ]
+            fileLink = await ytdl_down(opts, id[0])
+            await m.edit_text("Uploading...")
             thumnail = await thumb_down(id[0])
             AForCopy = await message.reply_audio(
                 fileLink,


### PR DESCRIPTION
## Summary
- display animated progress bar while downloading YouTube audio
- fix progress bar updates by scheduling edits on the client's event loop

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6a5953888323b4e932f723b66bd3