### PR TITLE
Add upload progress bar for uploads

### DIFF
--- a/mbot/plugins/youtube.py
+++ b/mbot/plugins/youtube.py
@@ -29,6 +29,7 @@ from shutil import rmtree
 from pyrogram import filters
 
 from mbot import AUTH_CHATS, LOG_GROUP, LOGGER, Mbot
+from mbot.utils.progress import upload_progress_hook_factory
 from mbot.utils.ytdl import audio_opt, getIds, thumb_down, ytdl_down
 
 
@@ -106,6 +107,9 @@ async def _(client, message):
                 performer=id[2],
                 thumb=thumnail,
                 duration=id[4],
+                progress=upload_progress_hook_factory(
+                    client, m, idx, videoInPlaylist, id[3]
+                ),
             )
             if LOG_GROUP:
                 await PForCopy.copy(LOG_GROUP)

--- a/mbot/utils/progress.py
+++ b/mbot/utils/progress.py
@@ -1,0 +1,27 @@
+from asyncio import AbstractEventLoop
+
+
+def upload_progress_hook_factory(client, message, index, total, title):
+    bar_length = 20
+    loop: AbstractEventLoop = client.loop
+
+    def progress(current, total_size):
+        percent = (current * 100 / total_size) if total_size else 0
+        percent_str = f"{percent:.1f}%"
+        filled = int(bar_length * percent // 100)
+        bar = "█" * filled + "░" * (bar_length - filled)
+        text = (
+            f"Uploading {index}/{total}\n"
+            f"{title}\n"
+            f"`[{bar}] {percent_str}`"
+        )
+        if current < total_size:
+            loop.call_soon_threadsafe(
+                loop.create_task, message.edit_text(text)
+            )
+        else:
+            loop.call_soon_threadsafe(
+                loop.create_task, message.edit_text("Upload complete.")
+            )
+
+    return progress


### PR DESCRIPTION
## Summary
- add generic upload progress hook
- display upload progress bar when sending YouTube downloads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af71bda1608323aac9420e43d28a59