### PR TITLE
Handle edit conflicts gracefully

### DIFF
--- a/mbot/plugins/deezer.py
+++ b/mbot/plugins/deezer.py
@@ -28,6 +28,8 @@ from shutil import rmtree
 from deezer import Client
 from pyrogram import filters
 
+from mbot.utils.pyrohelper import safe_edit
+
 from mbot import AUTH_CHATS, LOG_GROUP, Mbot
 from mbot.utils.mainhelper import (
     download_songs,
@@ -81,10 +83,11 @@ async def link_handler(_, message):
             rmtree(randomdir, ignore_errors=True)
             await m.delete()
         elif item_type == "artist":
-            await m.edit_text(
-                "This Is An Artist Account Link. Send me Track, Playlist or Album Link :)"
+            await safe_edit(
+                m,
+                "This Is An Artist Account Link. Send me Track, Playlist or Album Link :)",
             )
         else:
-            await m.edit_text("Link Type Not Available for Download.")
+            await safe_edit(m, "Link Type Not Available for Download.")
     except Exception as e:
-        await m.edit_text(f"Error: {e}", quote=True)
+        await safe_edit(m, f"Error: {e}", quote=True)

--- a/mbot/plugins/greetings.py
+++ b/mbot/plugins/greetings.py
@@ -28,6 +28,8 @@ from pyrogram import filters
 from pyrogram.raw.functions import Ping
 from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
+from mbot.utils.pyrohelper import safe_edit
+
 from mbot import AUTH_CHATS, LOG_GROUP, OWNER_ID, SUDO_USERS, Mbot
 
 
@@ -126,7 +128,7 @@ async def helpbtn(_, query):
         [[InlineKeyboardButton("Back", callback_data="helphome")]]
     )
     text = f"Help for **{i}**\n\n{HELP[i]}"
-    await query.message.edit(text=text, reply_markup=button)
+    await safe_edit(query.message, text, reply_markup=button)
 
 
 @Mbot.on_callback_query(filters.regex(r"helphome"))
@@ -134,7 +136,8 @@ async def help_home(_, query):
     button = [
         [InlineKeyboardButton(text=i, callback_data=f"help_{i}")] for i in HELP
     ]
-    await query.message.edit(
+    await safe_edit(
+        query.message,
         f"Hello **{query.from_user.first_name}**, I'm **@NeedMusicRobot**.\nI'm Here to download your music.",
         reply_markup=InlineKeyboardMarkup(button),
     )

--- a/mbot/plugins/spotify.py
+++ b/mbot/plugins/spotify.py
@@ -28,6 +28,8 @@ from shutil import rmtree
 import spotipy
 from pyrogram import filters
 
+from mbot.utils.pyrohelper import safe_edit
+
 from mbot import AUTH_CHATS, LOG_GROUP, LOGGER, Mbot
 from mbot.utils.mainhelper import (
     copy,
@@ -165,4 +167,4 @@ async def spotify_dl(_, message):
             return await m.delete()
     except Exception as e:
         LOGGER.error(e)
-        await m.edit_text(e)
+        await safe_edit(m, e)

--- a/mbot/utils/progress.py
+++ b/mbot/utils/progress.py
@@ -1,5 +1,7 @@
 from asyncio import AbstractEventLoop
 
+from .pyrohelper import safe_edit
+
 
 def upload_progress_hook_factory(client, message, index, total, title):
     bar_length = 20
@@ -17,11 +19,11 @@ def upload_progress_hook_factory(client, message, index, total, title):
         )
         if current < total_size:
             loop.call_soon_threadsafe(
-                loop.create_task, message.edit_text(text)
+                loop.create_task, safe_edit(message, text)
             )
         else:
             loop.call_soon_threadsafe(
-                loop.create_task, message.edit_text("Upload complete.")
+                loop.create_task, safe_edit(message, "Upload complete.")
             )
 
     return progress

--- a/mbot/utils/pyrohelper.py
+++ b/mbot/utils/pyrohelper.py
@@ -1,0 +1,10 @@
+from pyrogram.errors import MessageNotModified
+
+
+async def safe_edit(message, *args, **kwargs):
+    """Edit a message while gracefully handling MessageNotModified."""
+    try:
+        return await message.edit_text(*args, **kwargs)
+    except MessageNotModified:
+        # Ignore attempts to edit with the same content
+        return message


### PR DESCRIPTION
## Summary
- ignore Telegram's `MessageNotModified` errors by adding `safe_edit`
- use `safe_edit` for progress updates and plugin message edits to prevent crashes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0b5167b408323a07648ea329b4128