### PR TITLE
Ensure event loop exists before importing pyrogram

### DIFF
--- a/mbot/__init__.py
+++ b/mbot/__init__.py
@@ -21,10 +21,19 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+import asyncio
 import logging
 from os import environ, mkdir, path, sys
 
 from dotenv import load_dotenv
+
+# Python 3.10+ no longer creates a default event loop automatically.
+# Ensure one exists before importing pyrogram, which expects it.
+try:  # pragma: no cover - simple compatibility shim
+    asyncio.get_running_loop()
+except RuntimeError:
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
 from pyrogram import Client
 
 load_dotenv("config.env")


### PR DESCRIPTION
## Summary
- Initialize a default asyncio event loop before importing pyrogram so startup works on Python 3.10+

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1599e8a888323ad0b418ce34849ef